### PR TITLE
Clippy Lints

### DIFF
--- a/src/components/timesheet.rs
+++ b/src/components/timesheet.rs
@@ -55,7 +55,7 @@ pub fn TimeSheetDisplay(timesheet: TimeSheet) -> impl IntoView {
                             <td>{day.to_string()}</td>
                             <td>
                                 {entries
-                                    .into_iter()
+                                    .iter()
                                     .map(|entry| view! { <Entry entry=entry/> })
                                     .collect_view()}
                             </td>

--- a/src/screens/magic_link.rs
+++ b/src/screens/magic_link.rs
@@ -13,7 +13,7 @@ pub fn MagicLink() -> impl IntoView {
     let magic_sign_in = create_server_action::<MagicSignIn>();
     match params() {
         Ok(MagicLinkParams{link}) => {
-            magic_sign_in.dispatch(MagicSignIn { link: link.clone()});
+            magic_sign_in.dispatch(MagicSignIn { link });
             view! { <div>"Loading..."</div> }
         },
         Err(e) => view! { <div>"Error parsing Parameters: " {e.to_string()}</div> }

--- a/src/screens/timesheets.rs
+++ b/src/screens/timesheets.rs
@@ -60,7 +60,7 @@ async fn load_hourly_users() -> Result<Vec<UserPublic>, ServerFnError> {
 pub fn TimeSheetsList() -> impl IntoView {
     let (current_user, set_current_user) = create_signal(String::new());
     let users = create_resource(move || {}, move |_| load_hourly_users());
-    let timesheet = create_resource(move || current_user(), move |user_id| load_timesheet_for(user_id));
+    let timesheet = create_resource(current_user, load_timesheet_for);
 
     create_effect( { move |_|
         leptos::logging::log!("{:?}", current_user())
@@ -80,7 +80,7 @@ pub fn TimeSheetsList() -> impl IntoView {
                                 id="user_selected"
                                 on:change=move |e| set_current_user(event_target_value(&e))
                             >
-                                <Show when=move || current_user().len() == 0>
+                                <Show when=move || current_user().is_empty()>
                                     <option value="">"-- Select User --"</option>
                                 </Show>
                                 {a
@@ -102,7 +102,7 @@ pub fn TimeSheetsList() -> impl IntoView {
                 _ => view! { <div>"Server Error"</div> },
             }}
             <Show when=move || {
-                current_user().len() != 0
+                !current_user().is_empty()
             }>
                 {move || match timesheet() {
                     Some(Ok(timesheet)) => {


### PR DESCRIPTION
<details open="true"><summary>Implemented Clippy Lints</summary>

> ## TL;DR
> This pull request includes changes to the `timesheet.rs`, `magic_link.rs`, and `timesheets.rs` files. The changes mainly involve refactoring and improving the code readability.
> 
> ## What changed
> In `timesheet.rs`, the `into_iter()` method was replaced with `iter()` to avoid consuming the `entries` vector. 
> 
> In `magic_link.rs`, the `link` variable was passed directly to the `dispatch` method instead of cloning it first. 
> 
> In `timesheets.rs`, several changes were made:
> - The `create_resource` function was simplified by passing the `current_user` and `load_timesheet_for` directly.
> - The `len() == 0` and `len() != 0` checks were replaced with `is_empty()` and `!is_empty()` respectively for better readability.

> ## Why make this change
> These changes were made to improve the code readability and efficiency. Using `iter()` instead of `into_iter()` avoids consuming the vector, passing the `link` variable directly avoids unnecessary cloning, and using `is_empty()` and `!is_empty()` makes the code more readable. The simplification of the `create_resource` function also makes the code cleaner and easier to understand.
</details>