### PR TITLE
add timesheet totals and only show revelant fields

### DIFF
--- a/src/components/timesheet.rs
+++ b/src/components/timesheet.rs
@@ -7,17 +7,23 @@ use crate::utils::miliseconds_to_string;
 
 #[component]
 pub fn TimeSheetDisplay(timesheet: TimeSheet) -> impl IntoView {
+    let (_entry_total, _adjustment_total, statuatory_total, vacation_total) = timesheet.summary_totals;
     view! {
         <table id="timesheet_summary">
             <thead>
                 <tr>
                     <th>"Day"</th>
-                    <th>"Checkins"</th>
-                    <th>"Adjustments"</th>
-                    <th>"Subtotal"</th>
-                    <th>"Statutory"</th>
-                    <th>"Vacation"</th>
-                    <th>"Total"</th>
+                    <th>"Hours"</th>
+                    {if statuatory_total > 0 {
+                        view! { <th>"Statutory"</th> }.into_view()
+                    } else {
+                        view! {}.into_view()
+                    }}
+                    {if vacation_total > 0 {
+                        view! { <th>"Vacation"</th> }.into_view()
+                    } else {
+                        view! {}.into_view()
+                    }}
                 </tr>
             </thead>
             {timesheet
@@ -27,12 +33,20 @@ pub fn TimeSheetDisplay(timesheet: TimeSheet) -> impl IntoView {
                     view! {
                         <tr>
                             <td data-title="Day">{day.to_string()}</td>
-                            <td data-title="Checkins">{miliseconds_to_string(time)}</td>
-                            <td data-title="Adjustments">{miliseconds_to_string(b)}</td>
-                            <td data-title="Subtotal">{miliseconds_to_string(&(time + b))}</td>
-                            <td data-title="Statutory">{miliseconds_to_string(c)}</td>
-                            <td data-title="Vacation">{miliseconds_to_string(d)}</td>
-                            <td data-title="Total">{miliseconds_to_string(&(time + b + c + d))}</td>
+                            <td data-title="Hours">{miliseconds_to_string(&(time + b))}</td>
+                            {if statuatory_total > 0 {
+                                view! { <td data-title="Statutory">{miliseconds_to_string(c)}</td> }
+                                    .into_view()
+                            } else {
+                                view! {}.into_view()
+                            }}
+                            {if vacation_total > 0 {
+                                view! { <td data-title="Vacation">{miliseconds_to_string(d)}</td> }
+                                    .into_view()
+                            } else {
+                                view! {}.into_view()
+                            }}
+
                         </tr>
                     }
                 })
@@ -55,10 +69,12 @@ pub fn TimeSheetDisplay(timesheet: TimeSheet) -> impl IntoView {
                         <tr class="entry">
                             <td>{day.to_string()}</td>
                             <td>
-                                {entries
-                                    .iter()
-                                    .map(|entry| view! { <Entry entry=entry/> })
-                                    .collect_view()}
+                                <table>
+                                    {entries
+                                        .iter()
+                                        .map(|entry| view! { <Entry entry=entry/> })
+                                        .collect_view()}
+                                </table>
                             </td>
                         </tr>
                     }

--- a/src/models/time_sheets.rs
+++ b/src/models/time_sheets.rs
@@ -13,6 +13,7 @@ pub struct TimeSheet {
     pub state: i32,
     pub entries: BTreeMap<NaiveDate, Vec<Entry>>,
     pub summary: BTreeMap<NaiveDate, (i64, i64, i64, i64)>,
+    pub summary_totals: (i64, i64, i64, i64)
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -76,6 +77,7 @@ impl TimeSheet {
         } = vals.user;
         let entries = generate_entries(vals.adjustments, vals.sessions);
         let summary = generate_summary(&entries);
+        let summary_totals = generate_summary_totals(&summary);
         Self {
             id,
             first_name,
@@ -84,6 +86,7 @@ impl TimeSheet {
             state,
             entries,
             summary,
+            summary_totals,
         }
     }
 }
@@ -184,4 +187,9 @@ fn generate_entries(
         }
     });
     map
+}
+
+#[cfg(feature = "ssr")]
+fn generate_summary_totals(summary: &BTreeMap<NaiveDate, (i64, i64, i64, i64)>) -> (i64, i64, i64, i64) {
+    summary.iter().fold((0, 0, 0, 0), |(s1, s2, s3, s4), (_, (e1, e2, e3, e4))| (s1 + e1, s2 + e2, s3 + e3, s4 + e4))
 }


### PR DESCRIPTION
It adds clarity and saves space by only showing the `Statutory` and `Vacation` columns when they have information in them.

Also added a summary totals to the timesheet structure.