### PR TITLE
show the state of the session

### DIFF
--- a/src/components/session.rs
+++ b/src/components/session.rs
@@ -32,15 +32,24 @@ pub fn Session<'a>(session: &'a Session) -> impl IntoView {
                                 .to_string()}
                         </td>
 
-                        {if session.state == 1 {
-                            view! {
+                        {match session.state {
+                            0 => view!{<td>"open"</td>}.into_view(),
+                            1 => view! {
                                 <td>
                                     <A href=format!("/app/timesheet/edit/{}", id)>edit</A>
                                 </td>
                             }
-                                .into_view()
-                        } else {
-                            view! {}.into_view()
+                                .into_view(),
+                            2 => view!{<td><A href=format!("/app/timesheet/edit/{}", id)>error</A></td>}.into_view(),
+                            3 => view!{
+                                <td>
+                                    "pending"
+                                </td>
+                            }.into_view(),
+                            4 => view!{<td>"accepted"</td>}.into_view(),
+                            5 => view!{<td>"rejected"</td>}.into_view(),
+                            6 => view!{<td>"done"</td>}.into_view(),
+                            _ => view!{<td data-state="error">"ERROR"</td>}.into_view(),
                         }}
                     }
                         .into_view()


### PR DESCRIPTION
This pull request updates the `session.rs` file to handle different session states. Instead of only handling a single state, it now handles seven different states, providing a more robust and comprehensive session management system.
 
## What changed
The `session.rs` file was updated to handle different session states. Previously, it only handled a single state (state == 1). Now, it can handle seven different states (0 to 6), each with its own view. If the state is not within this range, it will display an error.
