### PR TITLE
feat: Remove unnecessary error-handling for converting time

### DIFF
--- a/src/screens/timesheet.rs
+++ b/src/screens/timesheet.rs
@@ -103,9 +103,8 @@ async fn get_active_user_timesheet() -> Result<TimeSheet, ServerFnError> {
         leptos_axum::redirect("/sign_in");
         return Err(ServerFnError::ServerError("Error getting Session!".into()));
     };
-    let Some(now) = NaiveDateTime::from_timestamp_opt(Local::now().timestamp(), 0) else {
-        return Err(ServerFnError::ServerError("Error Converting Time".into()));
-    };
+
+    let now = Local::now().naive_local();
     let three_weeks_before = now.clone().date().week(Weekday::Mon).first_day() - Duration::days(14);
     let end_of_week = now.date().week(Weekday::Mon).last_day() + Duration::days(7);
 

--- a/src/screens/timesheets.rs
+++ b/src/screens/timesheets.rs
@@ -30,16 +30,14 @@ pub fn TimeSheets() -> impl IntoView {
 
 #[server]
 async fn load_timesheet_for<'a>(user_id: String) -> Result<TimeSheet, ServerFnError> {
-    use chrono::{Duration, Local, NaiveDateTime, Weekday};
+    use chrono::{Duration, Local, Weekday};
     use uuid::Uuid;
 
     let Ok(id) = Uuid::parse_str(&user_id) else {
         return Err(ServerFnError::Deserialization("Error parsing ID".into()));
     };
 
-    let Some(now) = NaiveDateTime::from_timestamp_opt(Local::now().timestamp(), 0) else {
-        return Err(ServerFnError::ServerError("Error Converting Time".into()));
-    };
+    let now = Local::now().naive_local();
     let three_weeks_before = now.clone().date().week(Weekday::Mon).first_day() - Duration::days(14);
     let end_of_week = now.date().week(Weekday::Mon).last_day() + Duration::days(7);
 


### PR DESCRIPTION
In the `timesheet.rs` and `timesheets.rs` files, the error-handling for
converting the current time to `NaiveDateTime` has been simplified. Instead
of checking for `Some(now)`, the conversion is now done using `Local::now()`
and `naive_local()` directly, removing an unnecessary conditional check.
This simplifies the code and improves readability.