### PR TITLE
chore(twilio): silence clippy and tidy trailing newline

### DIFF
--- a/libs/twilio/src/lib.rs
+++ b/libs/twilio/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+
 #[macro_use]
 extern crate serde_derive;
 
@@ -7,3 +9,4 @@ extern crate url;
 
 pub mod apis;
 pub mod models;
+


### PR DESCRIPTION
### **User description**
Add a crate-level allow for clippy lints in libs/twilio/src/lib.rs to
suppress lint noise during builds. Also append a trailing newline at the
end of the file and remove an extra blank line to keep file formatting
consistent.


___

### **PR Type**
Other


___

### **Description**
- Add clippy lint suppression at crate level

- Fix file formatting with proper trailing newline


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add clippy suppression and fix formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/twilio/src/lib.rs

<ul><li>Add <code>#![allow(clippy::all)]</code> directive at top of file<br> <li> Add proper trailing newline at end of file<br> <li> Insert blank line after clippy directive for formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/gavdaly/clockr/pull/42/files#diff-72907b5b48a4e0de1824562c897601881cdf11acd10afb8fd9fd0bbdcf05f5a8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

